### PR TITLE
Разделить установку рендер-состояний на отдельные функции (Blend/Depth/Rasterizer/Sampler)

### DIFF
--- a/Support/Dialogs/dlg_LoadGame.cpp
+++ b/Support/Dialogs/dlg_LoadGame.cpp
@@ -1913,12 +1913,12 @@ void dlg_load_game::platform_DrawSprite( const vector2& UpperLeft,
     draw_Begin( DRAW_SPRITES, DrawFlags );
 
     if( Additive )
-        state_SetState( STATE_TYPE_BLEND, STATE_BLEND_ADD );
+        state_SetBlend( STATE_BLEND_ADD );
     else
-        state_SetState( STATE_TYPE_BLEND, STATE_BLEND_ALPHA );
+        state_SetBlend( STATE_BLEND_ALPHA );
     
-    state_SetState( STATE_TYPE_DEPTH, STATE_DEPTH_DISABLED );
-    state_SetState( STATE_TYPE_RASTERIZER, STATE_RASTER_SOLID_NO_CULL );
+    state_SetDepth( STATE_DEPTH_DISABLED );
+    state_SetRasterizer( STATE_RASTER_SOLID_NO_CULL );
     
     draw_SpriteUV( ClippedUL,
                    ClippedSize,
@@ -1980,8 +1980,8 @@ void dlg_load_game::platform_BeginFogRender( void )
                               DRAW_NO_ZWRITE | 
                               DRAW_BLEND_ADD );
 
-    state_SetState( STATE_TYPE_BLEND, STATE_BLEND_ADD );
-    state_SetState( STATE_TYPE_DEPTH, STATE_DEPTH_DISABLED );
+    state_SetBlend( STATE_BLEND_ADD );
+    state_SetDepth( STATE_DEPTH_DISABLED );
     
     draw_SetTexture( m_FogBMP );
 #endif
@@ -2158,9 +2158,9 @@ void dlg_load_game::platform_BeginShaftRender( void )
                             DRAW_U_CLAMP    |
                             DRAW_V_CLAMP    );
 
-    state_SetState( STATE_TYPE_BLEND, STATE_BLEND_ADD );
-    state_SetState( STATE_TYPE_DEPTH, STATE_DEPTH_DISABLED );
-    state_SetState( STATE_TYPE_SAMPLER, STATE_SAMPLER_LINEAR_CLAMP );
+    state_SetBlend( STATE_BLEND_ADD );
+    state_SetDepth( STATE_DEPTH_DISABLED );
+    state_SetSampler( STATE_SAMPLER_LINEAR_CLAMP, 0, STATE_SAMPLER_STAGE_PS );
 #endif
 }
 

--- a/Support/Render/PC/MaterialMgr/MaterialMgr.cpp
+++ b/Support/Render/PC/MaterialMgr/MaterialMgr.cpp
@@ -293,10 +293,10 @@ void material_mgr::ApplyRenderStates( const material* pMaterial, u32 RenderFlags
     //    samplerMode = STATE_SAMPLER_LINEAR_CLAMP;
     //}
 
-    state_SetState( STATE_TYPE_BLEND,      blendMode );
-    state_SetState( STATE_TYPE_DEPTH,      depthMode );
-    state_SetState( STATE_TYPE_RASTERIZER, rasterMode );
-    state_SetState( STATE_TYPE_SAMPLER,    samplerMode );
+    state_SetBlend(      blendMode );
+    state_SetDepth(      depthMode );
+    state_SetRasterizer( rasterMode );
+    state_SetSampler(    samplerMode, 0, STATE_SAMPLER_STAGE_PS );
 }
 
 //==============================================================================

--- a/Support/Render/PC/PostMgr/PostMgr.cpp
+++ b/Support/Render/PC/PostMgr/PostMgr.cpp
@@ -363,17 +363,17 @@ xcolor post_mgr::GetFogValue( const vector3& WorldPos, s32 PaletteIndex )
 
 void post_mgr::PrepareFullscreenQuad( void ) const
 {
-    state_SetState( STATE_TYPE_DEPTH, STATE_DEPTH_DISABLED );
-    state_SetState( STATE_TYPE_RASTERIZER, STATE_RASTER_SOLID );
+    state_SetDepth( STATE_DEPTH_DISABLED );
+    state_SetRasterizer( STATE_RASTER_SOLID );
 }
 
 //==============================================================================
 
 void post_mgr::RestoreDefaultState( void ) const
 {
-    state_SetState( STATE_TYPE_DEPTH, STATE_DEPTH_NORMAL );
-    state_SetState( STATE_TYPE_BLEND, STATE_BLEND_NONE );
-    state_SetState( STATE_TYPE_RASTERIZER, STATE_RASTER_SOLID );
+    state_SetDepth( STATE_DEPTH_NORMAL );
+    state_SetBlend( STATE_BLEND_NONE );
+    state_SetRasterizer( STATE_RASTER_SOLID );
 }
 
 //==============================================================================

--- a/Support/Render/PC/PostMgr/PostMgr_Filters.cpp
+++ b/Support/Render/PC/PostMgr/PostMgr_Filters.cpp
@@ -103,7 +103,7 @@ void post_mgr::ExecuteScreenFade( void )
     Rect.r = m_PostViewR;
     Rect.b = m_PostViewB;
 
-    state_SetState( STATE_TYPE_BLEND, STATE_BLEND_ALPHA );
+    state_SetBlend( STATE_BLEND_ALPHA );
     draw_Rect( Rect, m_Simple.FadeColor, FALSE );
 }
 

--- a/xCore/Entropy/D3DEngine/d3deng.cpp
+++ b/xCore/Entropy/D3DEngine/d3deng.cpp
@@ -1048,10 +1048,10 @@ void d3deng_SetDefaultStates( void )
         rtarget_Clear( RTARGET_CLEAR_ALL, clearColor, 1.0f, 0 );
 
         // Set default blend state
-        state_SetState( STATE_TYPE_BLEND, STATE_BLEND_ALPHA );
+        state_SetBlend( STATE_BLEND_ALPHA );
 
         // Set default sampler state
-        state_SetState( STATE_TYPE_SAMPLER, STATE_SAMPLER_ANISOTROPIC_WRAP );
+        state_SetSampler( STATE_SAMPLER_ANISOTROPIC_WRAP, 0, STATE_SAMPLER_STAGE_PS );
     }
 }
 

--- a/xCore/Entropy/D3DEngine/d3deng_composite.cpp
+++ b/xCore/Entropy/D3DEngine/d3deng_composite.cpp
@@ -343,15 +343,15 @@ void composite_Blit( const rtarget& Source,
    }
 
     // Set up for composite rendering
-    state_SetState( STATE_TYPE_DEPTH, STATE_DEPTH_DISABLED_NO_WRITE );
-    state_SetState( STATE_TYPE_RASTERIZER, STATE_RASTER_SOLID_NO_CULL );
+    state_SetDepth( STATE_DEPTH_DISABLED_NO_WRITE );
+    state_SetRasterizer( STATE_RASTER_SOLID_NO_CULL );
 
     // Set blend mode based on composite blend mode
     state_blend_mode HardwareBlendMode = composite_GetHardwareBlendMode( BlendMode );
-    state_SetState( STATE_TYPE_BLEND, HardwareBlendMode );
+    state_SetBlend( HardwareBlendMode );
 
     // Set sampler
-    state_SetState( STATE_TYPE_SAMPLER, SamplerMode );
+    state_SetSampler( SamplerMode, 0, STATE_SAMPLER_STAGE_PS );
 
     // Set vertex buffer
     UINT stride = sizeof(composite_vertex);
@@ -387,6 +387,6 @@ void composite_Blit( const rtarget& Source,
     g_pd3dContext->PSSetShaderResources( 0, 1, &nullSRV );
 
     // Restore states
-    state_SetState( STATE_TYPE_DEPTH, STATE_DEPTH_NORMAL );
-    state_SetState( STATE_TYPE_RASTERIZER, STATE_RASTER_SOLID );
+    state_SetDepth( STATE_DEPTH_NORMAL );
+    state_SetRasterizer( STATE_RASTER_SOLID );
 }

--- a/xCore/Entropy/D3DEngine/d3deng_draw.cpp
+++ b/xCore/Entropy/D3DEngine/d3deng_draw.cpp
@@ -923,31 +923,31 @@ void draw_ApplyBlendState( u32 Flags )
     if( Flags & DRAW_BLEND_ADD )
     {
         if( draw_IsPremultipliedTargetActive() )
-            state_SetState( STATE_TYPE_BLEND, STATE_BLEND_PREMULT_ADD );
+            state_SetBlend( STATE_BLEND_PREMULT_ADD );
         else
-            state_SetState( STATE_TYPE_BLEND, STATE_BLEND_ADD );
+            state_SetBlend( STATE_BLEND_ADD );
     }
     else if( Flags & DRAW_BLEND_SUB )
     {
         if( draw_IsPremultipliedTargetActive() )
-            state_SetState( STATE_TYPE_BLEND, STATE_BLEND_PREMULT_SUB );
+            state_SetBlend( STATE_BLEND_PREMULT_SUB );
         else
-            state_SetState( STATE_TYPE_BLEND, STATE_BLEND_SUB );
+            state_SetBlend( STATE_BLEND_SUB );
     }
     else if( Flags & DRAW_BLEND_INTENSITY )
     {
-        state_SetState( STATE_TYPE_BLEND, STATE_BLEND_INTENSITY );
+        state_SetBlend( STATE_BLEND_INTENSITY );
     }
     else if( Flags & DRAW_USE_ALPHA )
     {
         if( draw_IsPremultipliedTargetActive() )
-            state_SetState( STATE_TYPE_BLEND, STATE_BLEND_PREMULT_ALPHA );
+            state_SetBlend( STATE_BLEND_PREMULT_ALPHA );
         else
-            state_SetState( STATE_TYPE_BLEND, STATE_BLEND_ALPHA );
+            state_SetBlend( STATE_BLEND_ALPHA );
     }
     else
     {
-        state_SetState( STATE_TYPE_BLEND, STATE_BLEND_NONE );
+        state_SetBlend( STATE_BLEND_NONE );
     }
 }
 
@@ -959,16 +959,16 @@ void draw_ApplyDepthState( u32 Flags )
     if( Flags & DRAW_NO_ZBUFFER )
     {
         if( Flags & DRAW_NO_ZWRITE )
-            state_SetState( STATE_TYPE_DEPTH, STATE_DEPTH_DISABLED_NO_WRITE );
+            state_SetDepth( STATE_DEPTH_DISABLED_NO_WRITE );
         else
-            state_SetState( STATE_TYPE_DEPTH, STATE_DEPTH_DISABLED );
+            state_SetDepth( STATE_DEPTH_DISABLED );
     }
     else
     {
         if( Flags & DRAW_NO_ZWRITE )
-            state_SetState( STATE_TYPE_DEPTH, STATE_DEPTH_NO_WRITE );
+            state_SetDepth( STATE_DEPTH_NO_WRITE );
         else
-            state_SetState( STATE_TYPE_DEPTH, STATE_DEPTH_NORMAL );
+            state_SetDepth( STATE_DEPTH_NORMAL );
     }
 }
 
@@ -980,16 +980,16 @@ void draw_ApplyRasterizerState( u32 Flags )
     if( Flags & DRAW_WIRE_FRAME )
     {
         if( Flags & DRAW_CULL_NONE )
-            state_SetState( STATE_TYPE_RASTERIZER, STATE_RASTER_WIRE_NO_CULL );
+            state_SetRasterizer( STATE_RASTER_WIRE_NO_CULL );
         else
-            state_SetState( STATE_TYPE_RASTERIZER, STATE_RASTER_WIRE );
+            state_SetRasterizer( STATE_RASTER_WIRE );
     }
     else
     {
         if( Flags & DRAW_CULL_NONE )
-            state_SetState( STATE_TYPE_RASTERIZER, STATE_RASTER_SOLID_NO_CULL );
+            state_SetRasterizer( STATE_RASTER_SOLID_NO_CULL );
         else
-            state_SetState( STATE_TYPE_RASTERIZER, STATE_RASTER_SOLID );
+            state_SetRasterizer( STATE_RASTER_SOLID );
     }
 }
 
@@ -1006,16 +1006,16 @@ void draw_ApplySamplerState( u32 Flags )
     if( s_bCurrentBilinear )
     {
         if( clamp )
-            state_SetState( STATE_TYPE_SAMPLER, STATE_SAMPLER_ANISOTROPIC_CLAMP ); //state_SetState( STATE_TYPE_SAMPLER, STATE_SAMPLER_LINEAR_CLAMP );
+            state_SetSampler( STATE_SAMPLER_ANISOTROPIC_CLAMP, 0, STATE_SAMPLER_STAGE_PS ); //state_SetSampler( STATE_SAMPLER_LINEAR_CLAMP );
         else
-            state_SetState( STATE_TYPE_SAMPLER, STATE_SAMPLER_ANISOTROPIC_WRAP ); //state_SetState( STATE_TYPE_SAMPLER, STATE_SAMPLER_LINEAR_WRAP );
+            state_SetSampler( STATE_SAMPLER_ANISOTROPIC_WRAP, 0, STATE_SAMPLER_STAGE_PS ); //state_SetSampler( STATE_SAMPLER_LINEAR_WRAP );
     }
     else
     {
         if( clamp )
-            state_SetState( STATE_TYPE_SAMPLER, STATE_SAMPLER_POINT_CLAMP );
+            state_SetSampler( STATE_SAMPLER_POINT_CLAMP, 0, STATE_SAMPLER_STAGE_PS );
         else
-            state_SetState( STATE_TYPE_SAMPLER, STATE_SAMPLER_POINT_WRAP );
+            state_SetSampler( STATE_SAMPLER_POINT_WRAP, 0, STATE_SAMPLER_STAGE_PS );
     }
 }
 
@@ -1157,7 +1157,7 @@ void draw_End( void )
     }
     
     // Restore depth state
-    state_SetState( STATE_TYPE_DEPTH, STATE_DEPTH_NORMAL );
+    state_SetDepth( STATE_DEPTH_NORMAL );
     
     // Restore standard matrices
     const view* pView = eng_GetView();
@@ -1184,10 +1184,10 @@ void draw_ResetAfterException( void )
         return;
 
     // Reset states to default
-    state_SetState( STATE_TYPE_BLEND, STATE_BLEND_ALPHA );
-    state_SetState( STATE_TYPE_DEPTH, STATE_DEPTH_NORMAL );
-    state_SetState( STATE_TYPE_RASTERIZER, STATE_RASTER_SOLID );
-    state_SetState( STATE_TYPE_SAMPLER, STATE_SAMPLER_LINEAR_WRAP );
+    state_SetBlend( STATE_BLEND_ALPHA );
+    state_SetDepth( STATE_DEPTH_NORMAL );
+    state_SetRasterizer( STATE_RASTER_SOLID );
+    state_SetSampler( STATE_SAMPLER_LINEAR_WRAP, 0, STATE_SAMPLER_STAGE_PS );
 }
 
 //==============================================================================
@@ -1851,7 +1851,7 @@ void draw_DisableBilinear( void )
     if( m_bBegin )
         draw_SetupRenderStates( m_Flags, m_IsTextured );
     else
-        state_SetState( STATE_TYPE_SAMPLER, STATE_SAMPLER_POINT_WRAP );
+        state_SetSampler( STATE_SAMPLER_POINT_WRAP, 0, STATE_SAMPLER_STAGE_PS );
 }
 
 //==============================================================================
@@ -1864,5 +1864,5 @@ void draw_EnableBilinear( void )
     if( m_bBegin )
         draw_SetupRenderStates( m_Flags, m_IsTextured );
     else
-        state_SetState( STATE_TYPE_SAMPLER, STATE_SAMPLER_LINEAR_WRAP );
+        state_SetSampler( STATE_SAMPLER_LINEAR_WRAP, 0, STATE_SAMPLER_STAGE_PS );
 }

--- a/xCore/Entropy/D3DEngine/d3deng_state.cpp
+++ b/xCore/Entropy/D3DEngine/d3deng_state.cpp
@@ -41,6 +41,17 @@ static ID3D11RasterizerState*   s_pRasterStates[STATE_RASTER_COUNT]   = { NULL }
 static ID3D11DepthStencilState* s_pDepthStates[STATE_DEPTH_COUNT]     = { NULL };
 static ID3D11SamplerState*      s_pSamplerStates[STATE_SAMPLER_COUNT] = { NULL };
 
+enum
+{
+    STATE_SAMPLER_STAGE_INDEX_PS = 0,
+    STATE_SAMPLER_STAGE_INDEX_VS,
+    STATE_SAMPLER_STAGE_INDEX_GS,
+    STATE_SAMPLER_STAGE_INDEX_CS,
+    STATE_SAMPLER_STAGE_INDEX_COUNT
+};
+
+static const u32 STATE_SAMPLER_MAX_SLOTS = D3D11_COMMONSHADER_SAMPLER_SLOT_COUNT;
+
 //==============================================================================
 //  STATE CACHE
 //==============================================================================
@@ -50,14 +61,23 @@ static struct state_cache
     state_blend_mode        CurrentBlendMode;
     state_raster_mode       CurrentRasterMode; 
     state_depth_mode        CurrentDepthMode;
-    state_sampler_mode      CurrentSamplerMode;
+    state_sampler_mode      CurrentSamplerMode[STATE_SAMPLER_STAGE_INDEX_COUNT][D3D11_COMMONSHADER_SAMPLER_SLOT_COUNT];
     xbool                   bInitialized;
     
     state_cache( void ) : CurrentBlendMode(STATE_BLEND_NONE), 
                           CurrentRasterMode(STATE_RASTER_SOLID),
                           CurrentDepthMode(STATE_DEPTH_NORMAL),
-                          CurrentSamplerMode(STATE_SAMPLER_LINEAR_WRAP),
-                          bInitialized(FALSE) {}
+                          bInitialized(FALSE)
+    {
+        s32 Stage;
+        s32 Slot;
+
+        for( Stage = 0; Stage < STATE_SAMPLER_STAGE_INDEX_COUNT; Stage++ )
+        {
+            for( Slot = 0; Slot < (s32)STATE_SAMPLER_MAX_SLOTS; Slot++ )
+                CurrentSamplerMode[Stage][Slot] = STATE_SAMPLER_LINEAR_WRAP;
+        }
+    }
 } s_StateCache;
 
 //==============================================================================
@@ -708,7 +728,229 @@ void state_Kill( void )
 //  STATE MANAGEMENT FUNCTIONS
 //==============================================================================
 
-xbool state_SetState( state_type Type, s32 Mode )
+xbool state_SetBlend( state_blend_mode Mode )
+{
+    if( !s_StateCache.bInitialized )
+    {
+        x_DebugMsg( "RStateMgr: Not initialized\n" );
+        ASSERT(FALSE);
+        return FALSE;
+    }
+
+    if( !g_pd3dContext )
+        return FALSE;
+
+    if( Mode >= STATE_BLEND_COUNT )
+    {
+        x_DebugMsg( "RStateMgr: Invalid blend mode %d\n", Mode );
+        ASSERT(FALSE);
+        return FALSE;
+    }
+
+    if( s_StateCache.CurrentBlendMode == Mode )
+    {
+        #ifdef STATE_VERBOSE_MODE
+        x_DebugMsg( "RStateMgr: Blend %s CACHED\n", state_GetModeName(STATE_TYPE_BLEND, Mode) );
+        #endif
+        return FALSE;
+    }
+
+    if( !s_pBlendStates[Mode] )
+    {
+        x_DebugMsg( "RStateMgr: Blend state %s not created\n", state_GetModeName(STATE_TYPE_BLEND, Mode) );
+        ASSERT(FALSE);
+        return FALSE;
+    }
+
+    g_pd3dContext->OMSetBlendState( s_pBlendStates[Mode], NULL, D3D11_DEFAULT_SAMPLE_MASK );
+    s_StateCache.CurrentBlendMode = Mode;
+
+    #ifdef STATE_VERBOSE_MODE
+    x_DebugMsg( "RStateMgr: Blend mode set to %s\n", state_GetModeName(STATE_TYPE_BLEND, Mode) );
+    #endif
+    return TRUE;
+}
+
+//==============================================================================
+
+xbool state_SetRasterizer( state_raster_mode Mode )
+{
+    if( !s_StateCache.bInitialized )
+    {
+        x_DebugMsg( "RStateMgr: Not initialized\n" );
+        ASSERT(FALSE);
+        return FALSE;
+    }
+
+    if( !g_pd3dContext )
+        return FALSE;
+
+    if( Mode >= STATE_RASTER_COUNT )
+    {
+        x_DebugMsg( "RStateMgr: Invalid rasterizer mode %d\n", Mode );
+        ASSERT(FALSE);
+        return FALSE;
+    }
+
+    if( s_StateCache.CurrentRasterMode == Mode )
+    {
+        #ifdef STATE_VERBOSE_MODE
+        x_DebugMsg( "RStateMgr: Rasterizer %s CACHED\n", state_GetModeName(STATE_TYPE_RASTERIZER, Mode) );
+        #endif
+        return FALSE;
+    }
+
+    if( !s_pRasterStates[Mode] )
+    {
+        x_DebugMsg( "RStateMgr: Rasterizer state %s not created\n", state_GetModeName(STATE_TYPE_RASTERIZER, Mode) );
+        ASSERT(FALSE);
+        return FALSE;
+    }
+
+    g_pd3dContext->RSSetState( s_pRasterStates[Mode] );
+    s_StateCache.CurrentRasterMode = Mode;
+
+    #ifdef STATE_VERBOSE_MODE
+    x_DebugMsg( "RStateMgr: Rasterizer mode set to %s\n", state_GetModeName(STATE_TYPE_RASTERIZER, Mode) );
+    #endif
+    return TRUE;
+}
+
+//==============================================================================
+
+xbool state_SetDepth( state_depth_mode Mode )
+{
+    if( !s_StateCache.bInitialized )
+    {
+        x_DebugMsg( "RStateMgr: Not initialized\n" );
+        ASSERT(FALSE);
+        return FALSE;
+    }
+
+    if( !g_pd3dContext )
+        return FALSE;
+
+    if( Mode >= STATE_DEPTH_COUNT )
+    {
+        x_DebugMsg( "RStateMgr: Invalid depth mode %d\n", Mode );
+        ASSERT(FALSE);
+        return FALSE;
+    }
+
+    if( s_StateCache.CurrentDepthMode == Mode )
+    {
+        #ifdef STATE_VERBOSE_MODE
+        x_DebugMsg( "RStateMgr: Depth %s CACHED\n", state_GetModeName(STATE_TYPE_DEPTH, Mode) );
+        #endif
+        return FALSE;
+    }
+
+    if( !s_pDepthStates[Mode] )
+    {
+        x_DebugMsg( "RStateMgr: Depth state %s not created\n", state_GetModeName(STATE_TYPE_DEPTH, Mode) );
+        ASSERT(FALSE);
+        return FALSE;
+    }
+
+    g_pd3dContext->OMSetDepthStencilState( s_pDepthStates[Mode], 0 );
+    s_StateCache.CurrentDepthMode = Mode;
+
+    #ifdef STATE_VERBOSE_MODE
+    x_DebugMsg( "RStateMgr: Depth mode set to %s\n", state_GetModeName(STATE_TYPE_DEPTH, Mode) );
+    #endif
+    return TRUE;
+}
+
+//==============================================================================
+
+xbool state_SetSampler( state_sampler_mode Mode, u32 Slot, u32 StageMask )
+{
+    if( !s_StateCache.bInitialized )
+    {
+        x_DebugMsg( "RStateMgr: Not initialized\n" );
+        ASSERT(FALSE);
+        return FALSE;
+    }
+
+    if( !g_pd3dContext )
+        return FALSE;
+
+    if( Mode >= STATE_SAMPLER_COUNT )
+    {
+        x_DebugMsg( "RStateMgr: Invalid sampler mode %d\n", Mode );
+        ASSERT(FALSE);
+        return FALSE;
+    }
+
+    if( Slot >= STATE_SAMPLER_MAX_SLOTS )
+    {
+        x_DebugMsg( "RStateMgr: Invalid sampler slot %d\n", Slot );
+        ASSERT(FALSE);
+        return FALSE;
+    }
+
+    u32 SamplerMask = StageMask & STATE_SAMPLER_STAGE_ALL;
+    if( SamplerMask == 0 )
+    {
+        x_DebugMsg( "RStateMgr: Invalid sampler stage mask 0x%08X\n", StageMask );
+        ASSERT(FALSE);
+        return FALSE;
+    }
+
+    if( !s_pSamplerStates[Mode] )
+    {
+        x_DebugMsg( "RStateMgr: Sampler state %s not created\n", state_GetModeName(STATE_TYPE_SAMPLER, Mode) );
+        ASSERT(FALSE);
+        return FALSE;
+    }
+
+    ID3D11SamplerState* pSamplerState = s_pSamplerStates[Mode];
+    xbool bChanged = FALSE;
+
+    if( SamplerMask & STATE_SAMPLER_STAGE_PS )
+    {
+        if( s_StateCache.CurrentSamplerMode[STATE_SAMPLER_STAGE_INDEX_PS][Slot] != Mode )
+        {
+            g_pd3dContext->PSSetSamplers( Slot, 1, &pSamplerState );
+            s_StateCache.CurrentSamplerMode[STATE_SAMPLER_STAGE_INDEX_PS][Slot] = Mode;
+            bChanged = TRUE;
+        }
+    }
+
+    if( SamplerMask & STATE_SAMPLER_STAGE_VS )
+    {
+        if( s_StateCache.CurrentSamplerMode[STATE_SAMPLER_STAGE_INDEX_VS][Slot] != Mode )
+        {
+            g_pd3dContext->VSSetSamplers( Slot, 1, &pSamplerState );
+            s_StateCache.CurrentSamplerMode[STATE_SAMPLER_STAGE_INDEX_VS][Slot] = Mode;
+            bChanged = TRUE;
+        }
+    }
+
+    if( SamplerMask & STATE_SAMPLER_STAGE_GS )
+    {
+        if( s_StateCache.CurrentSamplerMode[STATE_SAMPLER_STAGE_INDEX_GS][Slot] != Mode )
+        {
+            g_pd3dContext->GSSetSamplers( Slot, 1, &pSamplerState );
+            s_StateCache.CurrentSamplerMode[STATE_SAMPLER_STAGE_INDEX_GS][Slot] = Mode;
+            bChanged = TRUE;
+        }
+    }
+
+    if( SamplerMask & STATE_SAMPLER_STAGE_CS )
+    {
+        if( s_StateCache.CurrentSamplerMode[STATE_SAMPLER_STAGE_INDEX_CS][Slot] != Mode )
+        {
+            g_pd3dContext->CSSetSamplers( Slot, 1, &pSamplerState );
+            s_StateCache.CurrentSamplerMode[STATE_SAMPLER_STAGE_INDEX_CS][Slot] = Mode;
+            bChanged = TRUE;
+        }
+    }
+
+    return bChanged;
+}
+
+xbool state_SetState( state_type Type, s32 Mode, u32 Slot, u32 StageMask )
 {
     if( !s_StateCache.bInitialized )
     {
@@ -722,155 +964,10 @@ xbool state_SetState( state_type Type, s32 Mode )
 
     switch( Type )
     {
-        case STATE_TYPE_BLEND:
-        {
-            if( Mode >= STATE_BLEND_COUNT )
-            {
-                x_DebugMsg( "RStateMgr: Invalid blend mode %d\n", Mode );
-                ASSERT(FALSE);
-                return FALSE;
-            }
-
-            state_blend_mode BlendMode = (state_blend_mode)Mode;
-            
-            // Check cache
-            if( s_StateCache.CurrentBlendMode == BlendMode )
-            {
-                #ifdef STATE_VERBOSE_MODE
-                x_DebugMsg( "RStateMgr: Blend %s CACHED\n", state_GetModeName(STATE_TYPE_BLEND, Mode) );
-                #endif
-                return FALSE;
-            }
-
-
-            if( !s_pBlendStates[Mode] )
-            {
-                x_DebugMsg( "RStateMgr: Blend state %s not created\n", state_GetModeName(STATE_TYPE_BLEND, Mode) );
-                ASSERT(FALSE);
-                return FALSE;
-            }
-
-            // Set the state
-            g_pd3dContext->OMSetBlendState( s_pBlendStates[Mode], NULL, D3D11_DEFAULT_SAMPLE_MASK );
-            s_StateCache.CurrentBlendMode = BlendMode;
-
-            #ifdef STATE_VERBOSE_MODE
-            x_DebugMsg( "RStateMgr: Blend mode set to %s\n", state_GetModeName(STATE_TYPE_BLEND, Mode) );
-            #endif
-            return TRUE;
-        }
-
-        case STATE_TYPE_RASTERIZER:
-        {
-            if( Mode >= STATE_RASTER_COUNT )
-            {
-                x_DebugMsg( "RStateMgr: Invalid rasterizer mode %d\n", Mode );
-                ASSERT(FALSE);
-                return FALSE;
-            }
-
-            state_raster_mode RasterMode = (state_raster_mode)Mode;
-            
-            // Check cache
-            if( s_StateCache.CurrentRasterMode == RasterMode )
-            {
-                #ifdef STATE_VERBOSE_MODE
-                x_DebugMsg( "RStateMgr: Rasterizer %s CACHED\n", state_GetModeName(STATE_TYPE_RASTERIZER, Mode) );
-                #endif
-                return FALSE;
-            }
-
-            if( !s_pRasterStates[Mode] )
-            {
-                x_DebugMsg( "RStateMgr: Rasterizer state %s not created\n", state_GetModeName(STATE_TYPE_RASTERIZER, Mode) );
-                ASSERT(FALSE);
-                return FALSE;
-            }
-
-            // Set the state
-            g_pd3dContext->RSSetState( s_pRasterStates[Mode] );
-            s_StateCache.CurrentRasterMode = RasterMode;
-
-            #ifdef STATE_VERBOSE_MODE
-            x_DebugMsg( "RStateMgr: Rasterizer mode set to %s\n", state_GetModeName(STATE_TYPE_RASTERIZER, Mode) );
-            #endif
-            return TRUE;
-        }
-
-        case STATE_TYPE_DEPTH:
-        {
-            if( Mode >= STATE_DEPTH_COUNT )
-            {
-                x_DebugMsg( "RStateMgr: Invalid depth mode %d\n", Mode );
-                ASSERT(FALSE);
-                return FALSE;
-            }
-
-            state_depth_mode DepthMode = (state_depth_mode)Mode;
-            
-            // Check cache
-            if( s_StateCache.CurrentDepthMode == DepthMode )
-            {
-                #ifdef STATE_VERBOSE_MODE
-                x_DebugMsg( "RStateMgr: Depth %s CACHED\n", state_GetModeName(STATE_TYPE_DEPTH, Mode) );
-                #endif
-                return FALSE;
-            }
-
-            if( !s_pDepthStates[Mode] )
-            {
-                x_DebugMsg( "RStateMgr: Depth state %s not created\n", state_GetModeName(STATE_TYPE_DEPTH, Mode) );
-                ASSERT(FALSE);
-                return FALSE;
-            }
-
-            // Set the state
-            g_pd3dContext->OMSetDepthStencilState( s_pDepthStates[Mode], 0 );
-            s_StateCache.CurrentDepthMode = DepthMode;
-
-            #ifdef STATE_VERBOSE_MODE
-            x_DebugMsg( "RStateMgr: Depth mode set to %s\n", state_GetModeName(STATE_TYPE_DEPTH, Mode) );
-            #endif
-            return TRUE;
-        }
-
-        case STATE_TYPE_SAMPLER:
-        {
-            if( Mode >= STATE_SAMPLER_COUNT )
-            {
-                x_DebugMsg( "RStateMgr: Invalid sampler mode %d\n", Mode );
-                ASSERT(FALSE);
-                return FALSE;
-            }
-
-            state_sampler_mode SamplerMode = (state_sampler_mode)Mode;
-            
-            // Check cache
-            if( s_StateCache.CurrentSamplerMode == SamplerMode )
-            {
-                #ifdef STATE_VERBOSE_MODE
-                x_DebugMsg( "RStateMgr: Sampler %s CACHED\n", state_GetModeName(STATE_TYPE_SAMPLER, Mode) );
-                #endif
-                return FALSE;
-            }
-
-            if( !s_pSamplerStates[Mode] )
-            {
-                x_DebugMsg( "RStateMgr: Sampler state %s not created\n", state_GetModeName(STATE_TYPE_SAMPLER, Mode) );
-                ASSERT(FALSE);
-                return FALSE;
-            }
-
-            // Set the state
-            g_pd3dContext->PSSetSamplers( 0, 1, &s_pSamplerStates[Mode] );
-            s_StateCache.CurrentSamplerMode = SamplerMode;
-
-            #ifdef STATE_VERBOSE_MODE
-            x_DebugMsg( "RStateMgr: Sampler mode set to %s\n", state_GetModeName(STATE_TYPE_SAMPLER, Mode) );
-            #endif
-            return TRUE;
-        }
-
+        case STATE_TYPE_BLEND:      return state_SetBlend( (state_blend_mode)Mode );
+        case STATE_TYPE_RASTERIZER: return state_SetRasterizer( (state_raster_mode)Mode );
+        case STATE_TYPE_DEPTH:      return state_SetDepth( (state_depth_mode)Mode );
+        case STATE_TYPE_SAMPLER:    return state_SetSampler( (state_sampler_mode)Mode, Slot, StageMask );
         default:
             x_DebugMsg( "RStateMgr: Invalid state type %d\n", Type );
             ASSERT(FALSE);
@@ -890,7 +987,14 @@ void state_FlushCache( void )
     s_StateCache.CurrentBlendMode   = STATE_BLEND_INVALID;
     s_StateCache.CurrentRasterMode  = STATE_RASTER_INVALID;
     s_StateCache.CurrentDepthMode   = STATE_DEPTH_INVALID;
-    s_StateCache.CurrentSamplerMode = STATE_SAMPLER_INVALID;
+    
+    s32 Stage;
+    s32 Slot;
+    for( Stage = 0; Stage < STATE_SAMPLER_STAGE_INDEX_COUNT; Stage++ )
+    {
+        for( Slot = 0; Slot < (s32)STATE_SAMPLER_MAX_SLOTS; Slot++ )
+            s_StateCache.CurrentSamplerMode[Stage][Slot] = STATE_SAMPLER_INVALID;
+    }
 }
 
 //==============================================================================
@@ -909,7 +1013,7 @@ s32 state_GetState( state_type Type )
         case STATE_TYPE_BLEND:      return (s32)s_StateCache.CurrentBlendMode;
         case STATE_TYPE_RASTERIZER: return (s32)s_StateCache.CurrentRasterMode;
         case STATE_TYPE_DEPTH:      return (s32)s_StateCache.CurrentDepthMode;
-        case STATE_TYPE_SAMPLER:    return (s32)s_StateCache.CurrentSamplerMode;
+        case STATE_TYPE_SAMPLER:    return (s32)s_StateCache.CurrentSamplerMode[STATE_SAMPLER_STAGE_INDEX_PS][0];
         default:
             x_DebugMsg( "RStateMgr: Invalid state type %d\n", Type );
             ASSERT(FALSE);
@@ -933,7 +1037,7 @@ xbool state_IsState( state_type Type, s32 Mode )
         case STATE_TYPE_BLEND:      return (s_StateCache.CurrentBlendMode   == (state_blend_mode)Mode);
         case STATE_TYPE_RASTERIZER: return (s_StateCache.CurrentRasterMode  == (state_raster_mode)Mode);
         case STATE_TYPE_DEPTH:      return (s_StateCache.CurrentDepthMode   == (state_depth_mode)Mode);
-        case STATE_TYPE_SAMPLER:    return (s_StateCache.CurrentSamplerMode == (state_sampler_mode)Mode);
+        case STATE_TYPE_SAMPLER:    return (s_StateCache.CurrentSamplerMode[STATE_SAMPLER_STAGE_INDEX_PS][0] == (state_sampler_mode)Mode);
         default:
             x_DebugMsg( "RStateMgr: Invalid state type %d\n", Type );
             ASSERT(FALSE);

--- a/xCore/Entropy/D3DEngine/d3deng_state.hpp
+++ b/xCore/Entropy/D3DEngine/d3deng_state.hpp
@@ -96,6 +96,20 @@ enum state_sampler_mode
     STATE_SAMPLER_INVALID = 0xFF
 };
 
+//------------------------------------------------------------------------------
+
+enum state_sampler_stage
+{
+    STATE_SAMPLER_STAGE_PS  = (1 << 0),
+    STATE_SAMPLER_STAGE_VS  = (1 << 1),
+    STATE_SAMPLER_STAGE_GS  = (1 << 2),
+    STATE_SAMPLER_STAGE_CS  = (1 << 3),
+    STATE_SAMPLER_STAGE_ALL = (STATE_SAMPLER_STAGE_PS |
+                               STATE_SAMPLER_STAGE_VS |
+                               STATE_SAMPLER_STAGE_GS |
+                               STATE_SAMPLER_STAGE_CS)
+};
+
 //==============================================================================
 //  SYSTEM FUNCTIONS
 //==============================================================================
@@ -108,8 +122,14 @@ void                state_Kill                 ( void );
 //  STATE MANAGEMENT FUNCTIONS
 //==============================================================================
 
-// State setter
-xbool               state_SetState             ( state_type Type, s32 Mode );
+// State setters
+xbool               state_SetBlend             ( state_blend_mode Mode );
+xbool               state_SetRasterizer        ( state_raster_mode Mode );
+xbool               state_SetDepth             ( state_depth_mode Mode );
+xbool               state_SetSampler           ( state_sampler_mode Mode, u32 Slot = 0, u32 StageMask = STATE_SAMPLER_STAGE_PS );
+
+// Legacy state setter
+xbool               state_SetState             ( state_type Type, s32 Mode, u32 Slot = 0, u32 StageMask = STATE_SAMPLER_STAGE_PS );
 
 //==============================================================================
 //  UTILITY FUNCTIONS


### PR DESCRIPTION
### Motivation
- Упростить и разграничить логику изменения рендер-состояний путём выделения специализированных API для каждого типа состояния вместо единого `state_SetState`.
- Позволить явную установку sampler'а с указанием `Slot` и `StageMask` и корректное кеширование привязки по стадиям шейдеров.
- Снизить размер больших switch-блоков и улучшить читабельность/поддерживаемость кода менеджера состояний.
- Сохранить совместимость: оставить `state_SetState` как legacy-обёртку, делегирующую новым функциям.

### Description
- Добавлены публичные функции: `state_SetBlend`, `state_SetRasterizer`, `state_SetDepth` и `state_SetSampler` (с параметрами `Slot` и `StageMask`) и оставлена `state_SetState` как wrapper в `d3deng_state.hpp`/`d3deng_state.cpp`.
- Реализована логика применения и кеширования для каждого нового сеттера, включая двухмерный кеш sampler'ов `CurrentSamplerMode[stage][slot]` и проверки валидности параметров; вызовы D3D контекста (`OMSetBlendState`, `RSSetState`, `OMSetDepthStencilState`, `PS/VS/GS/CSSetSamplers`) используются в соответствующих функциях.
- Обновлены места вызова по проекту: заменены вызовы `state_SetState(...)` на специализированные `state_SetBlend(...)`, `state_SetDepth(...)`, `state_SetRasterizer(...)` и `state_SetSampler(..., Slot, StageMask)` в файлах рендера и утилит (`d3deng_draw.cpp`, `d3deng_composite.cpp`, `d3deng.cpp`, `MaterialMgr.cpp`, `PostMgr*.cpp`, `dlg_LoadGame.cpp` и др.).
- Инициализация/сброс кеша адаптированы: `state_FlushCache` теперь сбрасывает массив sampler-режимов по всем стадиям и слотам.

### Testing
- Автоматические тесты не запускались после изменений.
- Юнит/интеграционные тесты не запускались и сборка локально не проверялась.
- Внесённые замены вызовов проверены статическим поиском по коду (`rg`) и изменения закоммичены в репозиторий.
- Рекомендуется выполнить локальную сборку и прогон CI перед интеграцией, чтобы убедиться в отсутствии регрессий на целевых платформах.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69616670969883239c883ee7d36ddfa7)